### PR TITLE
Fila dlq criada

### DIFF
--- a/src/main/java/com/enterprise/suporte/configuration/rabbit/RabbitConfig.java
+++ b/src/main/java/com/enterprise/suporte/configuration/rabbit/RabbitConfig.java
@@ -1,8 +1,8 @@
 package com.enterprise.suporte.configuration.rabbit;
 
 import org.springframework.amqp.core.*;
-import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -14,9 +14,16 @@ public class RabbitConfig {
     public static final String TICKET_HISTORY_EXCHANGE = "ticket.history.exchange";
     public static final String TICKET_HISTORY_ROUTING_KEY = "ticket.history";
 
+    public static final String TICKET_HISTORY_DLQ_QUEUE = "ticket.history.dlq.queue";
+    public static final String TICKET_HISTORY_DLQ_EXCHANGE = "ticket.history.dlq.exchange";
+    public static final String TICKET_HISTORY_DLQ_ROUTING_KEY = "ticket.history.dlq";
+
     @Bean
     public Queue ticketHistoryQueue() {
-        return new Queue(TICKET_HISTORY_QUEUE, true);
+        return QueueBuilder.durable(TICKET_HISTORY_QUEUE)
+                .withArgument("x-dead-letter-exchange", TICKET_HISTORY_DLQ_EXCHANGE)
+                .withArgument("x-dead-letter-routing-key", TICKET_HISTORY_DLQ_ROUTING_KEY)
+                .build();
     }
 
     @Bean
@@ -25,11 +32,72 @@ public class RabbitConfig {
     }
 
     @Bean
-    public Binding ticketHistoryBinding(Queue ticketHistoryQueue, DirectExchange ticketHistoryExchange) {
-        return BindingBuilder
-                .bind(ticketHistoryQueue)
-                .to(ticketHistoryExchange)
+    public Binding ticketHistoryBinding() {
+        return BindingBuilder.bind(ticketHistoryQueue())
+                .to(ticketHistoryExchange())
                 .with(TICKET_HISTORY_ROUTING_KEY);
+    }
+
+    @Bean
+    public Queue ticketHistoryDlqQueue() {
+        return QueueBuilder.durable(TICKET_HISTORY_DLQ_QUEUE).build();
+    }
+
+    @Bean
+    public DirectExchange ticketHistoryDlqExchange() {
+        return new DirectExchange(TICKET_HISTORY_DLQ_EXCHANGE);
+    }
+
+    @Bean
+    public Binding ticketHistoryDlqBinding() {
+        return BindingBuilder.bind(ticketHistoryDlqQueue())
+                .to(ticketHistoryDlqExchange())
+                .with(TICKET_HISTORY_DLQ_ROUTING_KEY);
+    }
+
+    public static final String NOTIFICATION_QUEUE = "notification.queue";
+    public static final String NOTIFICATION_EXCHANGE = "notification.exchange";
+    public static final String NOTIFICATION_ROUTING_KEY = "notification";
+
+    public static final String NOTIFICATION_DLQ_QUEUE = "notification.dlq.queue";
+    public static final String NOTIFICATION_DLQ_EXCHANGE = "notification.dlq.exchange";
+    public static final String NOTIFICATION_DLQ_ROUTING_KEY = "notification.dlq";
+
+    @Bean
+    public Queue notificationQueue() {
+        return QueueBuilder.durable(NOTIFICATION_QUEUE)
+                .withArgument("x-dead-letter-exchange", NOTIFICATION_DLQ_EXCHANGE)
+                .withArgument("x-dead-letter-routing-key", NOTIFICATION_DLQ_ROUTING_KEY)
+                .build();
+    }
+
+    @Bean
+    public TopicExchange notificationExchange() {
+        return new TopicExchange(NOTIFICATION_EXCHANGE);
+    }
+
+    @Bean
+    public Binding notificationBinding() {
+        return BindingBuilder.bind(notificationQueue())
+                .to(notificationExchange())
+                .with(NOTIFICATION_ROUTING_KEY);
+    }
+
+    @Bean
+    public Queue notificationDlqQueue() {
+        return QueueBuilder.durable(NOTIFICATION_DLQ_QUEUE).build();
+    }
+
+    @Bean
+    public TopicExchange notificationDlqExchange() {
+        return new TopicExchange(NOTIFICATION_DLQ_EXCHANGE);
+    }
+
+    @Bean
+    public Binding notificationDlqBinding() {
+        return BindingBuilder.bind(notificationDlqQueue())
+                .to(notificationDlqExchange())
+                .with(NOTIFICATION_DLQ_ROUTING_KEY);
     }
 
     @Bean
@@ -40,33 +108,11 @@ public class RabbitConfig {
     @Bean
     public SimpleRabbitListenerContainerFactory rabbitListenerContainerFactory(
             ConnectionFactory connectionFactory,
-            Jackson2JsonMessageConverter jsonMessageConverter) {
-
+            Jackson2JsonMessageConverter jsonMessageConverter
+    ) {
         SimpleRabbitListenerContainerFactory factory = new SimpleRabbitListenerContainerFactory();
         factory.setConnectionFactory(connectionFactory);
         factory.setMessageConverter(jsonMessageConverter);
         return factory;
     }
-
-    public static final String NOTIFICATION_QUEUE = "notification.queue";
-    public static final String NOTIFICATION_EXCHANGE = "notification.exchange";
-    public static final String NOTIFICATION_ROUTING_KEY = "notification";
-
-    @Bean
-    public Queue notificationQueue() {
-        return new Queue(NOTIFICATION_QUEUE, true);
-    }
-
-    @Bean
-    public TopicExchange notificationExchange() {
-        return new TopicExchange(NOTIFICATION_EXCHANGE);
-    }
-
-    @Bean
-    public Binding notificationBinding(Queue notificationQueue, TopicExchange notificationExchange) {
-        return BindingBuilder.bind(notificationQueue)
-                .to(notificationExchange)
-                .with(NOTIFICATION_ROUTING_KEY);
-    }
 }
-

--- a/src/main/java/com/enterprise/suporte/listener/DlqReprocess.java
+++ b/src/main/java/com/enterprise/suporte/listener/DlqReprocess.java
@@ -1,0 +1,34 @@
+package com.enterprise.suporte.listener;
+
+import com.enterprise.suporte.configuration.rabbit.RabbitConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class DlqReprocess {
+
+    private final AmqpTemplate amqpTemplate;
+
+    public void reprocessTicketHistory(String message) {
+        log.info("[DLQ Reprocess] Reenviando mensagem para ticket.history.queue");
+        amqpTemplate.convertAndSend(
+                RabbitConfig.TICKET_HISTORY_EXCHANGE,
+                RabbitConfig.TICKET_HISTORY_ROUTING_KEY,
+                message
+        );
+    }
+
+    public void reprocessNotification(String message) {
+        log.info("[DLQ Reprocess] Reenviando mensagem para notification.queue");
+        amqpTemplate.convertAndSend(
+                RabbitConfig.NOTIFICATION_EXCHANGE,
+                RabbitConfig.NOTIFICATION_ROUTING_KEY,
+                message
+        );
+    }
+}
+

--- a/src/main/java/com/enterprise/suporte/listener/NotificationDlqListener.java
+++ b/src/main/java/com/enterprise/suporte/listener/NotificationDlqListener.java
@@ -1,0 +1,20 @@
+package com.enterprise.suporte.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class NotificationDlqListener {
+
+    private final DlqReprocess dlqReprocess;
+
+    @RabbitListener(queues = "notification.dlq.queue")
+    public void consumeNotificationDlq(String message) {
+        log.error("[DLQ] Mensagem não processada em notification.queue: {}", message);
+        dlqReprocess.reprocessNotification(message);
+    }
+}

--- a/src/main/java/com/enterprise/suporte/listener/TicketHistoryDlqListener.java
+++ b/src/main/java/com/enterprise/suporte/listener/TicketHistoryDlqListener.java
@@ -1,0 +1,20 @@
+package com.enterprise.suporte.listener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class TicketHistoryDlqListener {
+
+    private final DlqReprocess dlqReprocess;
+
+    @RabbitListener(queues = "ticket.history.dlq.queue")
+    public void consumeTicketHistoryDlq(String message) {
+        log.error("[DLQ] Mensagem não processada em ticket.history.queue: {}", message);
+        dlqReprocess.reprocessNotification(message);
+    }
+}


### PR DESCRIPTION
Criada DLQ (Dead Letter Queue) para filas de Tickets e Notificações:

- Configuração de filas DLQ para capturar mensagens falhas;
- Atualização da RabbitConfig com filas de dead letter e bindings;
- Preparação do sistema para tratamento de mensagens rejeitadas ou expiradas.
